### PR TITLE
Edit item state handling

### DIFF
--- a/src/components/Firebase/firebase.js
+++ b/src/components/Firebase/firebase.js
@@ -304,6 +304,8 @@ class Firebase {
     neededItem.quantity = '';
     delete neededItem.createdAt;
     delete neededItem.editedAt;
+    delete neededItem.uid;
+    delete neededItem.parentId;
     //TODO: prevent creation of duplicate needs
     return this.createItem(needsListId, neededItem)
   }

--- a/src/components/Needs/ionic/index.jsx
+++ b/src/components/Needs/ionic/index.jsx
@@ -10,6 +10,7 @@ import { inject, observer } from 'mobx-react';
 
 import {Trans} from 'react-i18next';
 import { withEmailVerification } from '../../Session';
+import Avatar from '../../Reusables/ionic/Avatar';
 
 class NeedsPage extends NeedsModel {
   render() {
@@ -22,12 +23,12 @@ class NeedsPage extends NeedsModel {
         const owner = userStore.users[needsStore.currentNeedsList.shoppingListOwnerId]
         if (owner) return (
           <IonTitle size="large">
-            {/* 
-              // TODO: Display the Avatar of the owner
+            
+              {/* // TODO: Display the Avatar of the owner */}
               <Avatar
               size="35px"
               user={owner}
-            /> */}
+            />
             <span>
               <Trans>by</Trans> {owner.username}
             </span>

--- a/src/components/Needs/ionic/index.jsx
+++ b/src/components/Needs/ionic/index.jsx
@@ -25,10 +25,10 @@ class NeedsPage extends NeedsModel {
           <IonTitle size="large">
             
               {/* // TODO: Display the Avatar of the owner */}
-              <Avatar
+              {/* <Avatar
               size="35px"
               user={owner}
-            />
+            /> */}
             <span>
               <Trans>by</Trans> {owner.username}
             </span>

--- a/src/components/Reusables/ionic/Item.js
+++ b/src/components/Reusables/ionic/Item.js
@@ -47,7 +47,7 @@ class Item extends Component {
       onShopItem
     } = this.props;
 
-    const needIcon = !ownList && mode === ITEM_TYPE_NEED &&
+    const needIcon = !ownList && mode === ITEM_TYPE_POTENTIAL_NEED &&
       <IonButton onClick={() => onCreateNeed(item)} fill="add" size="large" slot="end" color="primary">
         <IonIcon icon={add} />
       </IonButton>

--- a/src/components/Reusables/keys.js
+++ b/src/components/Reusables/keys.js
@@ -1,0 +1,1 @@
+export const ENTER = 13;

--- a/src/components/Shopping/ionic/CreateShoppingItem.js
+++ b/src/components/Shopping/ionic/CreateShoppingItem.js
@@ -1,17 +1,22 @@
 import React, { Component } from "react";
-import { IonItem, IonButton, IonInput, IonSelect, IonSelectOption, IonLabel, IonIcon, IonToast } from "@ionic/react";
-import { ITEM_TYPE_SHOPPING, ITEM_TYPE_NEED } from "../../../constants/items";
+import { IonItem, IonButton, IonInput, IonSelect, IonSelectOption, IonIcon, IonToast } from "@ionic/react";
 
 import { withTranslation } from 'react-i18next';
 import { cartOutline } from "ionicons/icons";
-import { ENTER } from "../keys";
+import { ENTER } from "../../Reusables/keys";
 
-class EditItem extends Component {
+const EMPTY_ITEM = {
+  name: '',
+  quantity: '',
+  unit: '',
+}
+
+class CreateShoppingItem extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      ...props.item,
+      ...EMPTY_ITEM,
       showToast: false,
       message: "",
     }
@@ -22,21 +27,22 @@ class EditItem extends Component {
 
   concludeEditing() {
     const { t } = this.props;
-    const { name, quantity, unit } = this.state
+    const { name, quantity, unit = ''} = this.state
     if (name && quantity) {
       this.props.onEditingConcluded({
-        uid: this.props.item.uid,
         name,
         quantity,
         unit,
       })
+      this.setState({ ...EMPTY_ITEM })
     } else {
       this.setState({
         showToast: true,
         message: t('Name_and_quantity_mandatory')
       })
     }
-    this.quantityInput.current.setFocus()
+
+    this.nameInput.current.setFocus()
   }
 
   onChange(event) {
@@ -62,32 +68,28 @@ class EditItem extends Component {
 
     const { t } = this.props;
 
-    const unitOfMeasure = this.props.mode === ITEM_TYPE_SHOPPING
-      ? <IonSelect
+    const unitOfMeasure = 
+      <IonSelect
         value={unit}
         required="true"
-        onIonChange={e => this.setUnit(e.detail.value)}
-      >
+        onIonChange={e => this.setUnit(e.detail.value)}>
         <IonSelectOption>pc</IonSelectOption>
         <IonSelectOption>g</IonSelectOption>
         <IonSelectOption>kg</IonSelectOption>
         <IonSelectOption>l</IonSelectOption>
         <IonSelectOption>ml</IonSelectOption>
       </IonSelect>
-      : <IonLabel>{unit}</IonLabel>
 
     return (
       <>
         <IonItem style={{ width: "100%" }}>
           <IonInput
-            // autofocus={this.props.mode === ITEM_TYPE_NEW_SHOPPING && !name}
             placeholder={t('Item name')}
             name="name"
             value={name}
             onIonInput={event => this.onKeyPress(event)}
             onIonChange={event => this.onChange(event)}
             onIonBlur={event => this.onBlur(event)}
-            readonly={this.props.mode === ITEM_TYPE_NEED}
             required="true"
             autocapitalize
             autocorrect="on"
@@ -95,7 +97,6 @@ class EditItem extends Component {
             ref={this.nameInput}
           />
           <IonInput
-            // autofocus={(this.props.mode === ITEM_TYPE_NEED) || (this.props.mode === ITEM_TYPE_SHOPPING && name)}
             placeholder={t("Quantity")}
             name="quantity"
             type="number"
@@ -124,4 +125,4 @@ class EditItem extends Component {
   }
 }
 
-export default withTranslation()(EditItem)
+export default withTranslation()(CreateShoppingItem)

--- a/src/components/Shopping/ionic/ShoppingList.js
+++ b/src/components/Shopping/ionic/ShoppingList.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import Item from '../../Reusables/ionic/Item';
-import EditItem from '../../Reusables/ionic/EditItem';
 import { IonList, IonItem, IonReorderGroup } from '@ionic/react';
-import { ITEM_TYPE_NEW_SHOPPING } from '../../../constants/items';
+import CreateShoppingItem from './CreateShoppingItem';
 
 class ShoppingList extends Component {
   constructor(props) {
@@ -76,9 +75,8 @@ class ShoppingList extends Component {
       <>
         <IonList>
           <IonItem>
-            <EditItem
+            <CreateShoppingItem
               onEditingConcluded={this.onCreateComplete.bind(this)}
-              mode={ITEM_TYPE_NEW_SHOPPING}
             />
           </IonItem>
         </IonList>


### PR DESCRIPTION
This PR removes the same `EditItem` component from being used for the creation of the shopping list item.
It contains a lot of redundant code (it was a copy), but this should be fine at the current point in time. It takes a bit of complexity from  `EditItem`, particularly with respect to state handling which was very cumbersome earlier.

Also, it flattens the state of the  components (no dedicated `item` state-property anymore, but separate attributes for `name, quantity, unit`). This makes it possible, to atomically adjust the state when entering an input